### PR TITLE
Bug #12999: fixing the publication alias display when main location linked to removed component instance.

### DIFF
--- a/mobile-war/src/main/java/org/silverpeas/mobile/server/services/ServiceDocuments.java
+++ b/mobile-war/src/main/java/org/silverpeas/mobile/server/services/ServiceDocuments.java
@@ -315,7 +315,7 @@ public class ServiceDocuments extends AbstractRestWebService {
       }
       NodePK nodePK = new NodePK(topicId, instanceId);
       PublicationPK pubPK = new PublicationPK("useless", instanceId);
-      List<KmeliaPublication> publications = KmeliaService.get().getPublicationsOfFolder(nodePK,
+      List<KmeliaPublication> publications = KmeliaService.get().getAuthorizedPublicationsOfFolder(nodePK,
           getUserTopicProfile(nodePK.getId(), pubPK.getInstanceId()), getUser().getId(),
           isTreeStructure(pubPK.getInstanceId()));
       final int sort;


### PR DESCRIPTION
Taking into account renaming of a service signature.

Linked to PRs:
* https://github.com/Silverpeas/Silverpeas-Core/pull/1217
* https://github.com/Silverpeas/Silverpeas-Components/pull/783